### PR TITLE
Add image (file) fields to SEO analysis and XML Sitemaps

### DIFF
--- a/assets/pods-seo.js
+++ b/assets/pods-seo.js
@@ -129,8 +129,10 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 					var alt = '';
 
 					if ( jQuery( '.pods-flex-name input', this ).length ) {
+						// Titles are editable
 						alt = jQuery( '.pods-flex-name input', this ).val();
 					} else {
+						// Just the image titles (not advisable for good analysis)
 						alt = jQuery( '.pods-flex-name', this ).text();
 					}
 					content += ' <img src="' + img + '" alt="' + alt.trim() + '" />';
@@ -146,8 +148,10 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 					var alt = '';
 
 					if ( jQuery( '.pods-file-name input', this ).length ) {
+						// Titles are editable
 						alt = jQuery( '.pods-file-name input', this ).val();
 					} else {
+						// Just the image titles (not advisable for good analysis)
 						alt = jQuery( '.pods-file-name', this ).text();
 					}
 					content += ' <img src="' + img + '" alt="' + alt.trim() + '" />';

--- a/assets/pods-seo.js
+++ b/assets/pods-seo.js
@@ -112,7 +112,7 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 
 	/**
 	 * Get image content from image fields and convert them to a HTML string for analyzing
-	 * @since 2.1
+	 * @since 2.0.1
 	 */
 	function pods_get_image_content( $element ) {
 

--- a/assets/pods-seo.js
+++ b/assets/pods-seo.js
@@ -8,15 +8,15 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 
 		var pods_key,
 			$pods_field,
-			pods_value;
+			pods_value = '';
 
 		pods_field_content = '';
 
-		for ( pods_key in pods_seo_settings.fields ) {
-			$pods_field = jQuery( pods_seo_settings.fields[ pods_key ] );
+		// Text
+		for ( pods_key in pods_seo_settings.fields.text ) {
+			$pods_field = jQuery( pods_seo_settings.fields.text[ pods_key ] );
 
 			if ( $pods_field[0] ) {
-				pods_value = '';
 
 				$pods_field.each( function() {
 
@@ -28,10 +28,30 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 
 				} );
 
-				if ( '' !== pods_value ) {
-					pods_field_content += ' ' + pods_value;
-				}
 			}
+		}
+
+		// Images
+		for ( pods_key in pods_seo_settings.fields.images ) {
+			$pods_field = jQuery( pods_seo_settings.fields.images[ pods_key ] );
+
+			if ( $pods_field[0] ) {
+
+				$pods_field.each( function() {
+
+					var value = pods_get_image_content( jQuery( this ) );
+
+					if ( '' !== value ) {
+						pods_value += ' ' + value;
+					}
+
+				} );
+
+			}
+		}
+
+		if ( '' !== pods_value ) {
+			pods_field_content += ' ' + pods_value;
 		}
 
 	}
@@ -88,6 +108,55 @@ jQuery( window ).on( 'YoastSEO:ready', function() {
 
 		return is_tinymce;
 
+	}
+
+	/**
+	 * Get image content from image fields and convert them to a HTML string for analyzing
+	 * @since 2.1
+	 */
+	function pods_get_image_content( $element ) {
+
+		var content = '';
+
+		if ( $element[0] ) {
+			
+			// Pods 2.7+
+			if ( $element.find('.pods-flex-list').length ) {
+
+				$element.find('.pods-flex-item').each( function() {
+
+					var img = jQuery( '.pods-flex-icon img', this ).attr( 'src' );
+					var alt = '';
+
+					if ( jQuery( '.pods-flex-name input', this ).length ) {
+						alt = jQuery( '.pods-flex-name input', this ).val();
+					} else {
+						alt = jQuery( '.pods-flex-name', this ).text();
+					}
+					content += ' <img src="' + img + '" alt="' + alt.trim() + '" />';
+				} );
+			}
+
+			// Pods < 2.7
+			if ( $element.find('pods-files-list').length ) {
+
+				$element.find('.pods-file').each( function() {
+
+					var img = jQuery( '.pods-file-icon img', this ).attr( 'src' );
+					var alt = '';
+
+					if ( jQuery( '.pods-file-name input', this ).length ) {
+						alt = jQuery( '.pods-file-name input', this ).val();
+					} else {
+						alt = jQuery( '.pods-file-name', this ).text();
+					}
+					content += ' <img src="' + img + '" alt="' + alt.trim() + '" />';
+				} );
+			}
+
+		}
+
+		return content;
 	}
 
 } );

--- a/classes/pods-seo-wpseo.php
+++ b/classes/pods-seo-wpseo.php
@@ -159,6 +159,7 @@ class Pods_SEO_WPSEO {
 			'paragraph',
 			'text',
 			'wysiwyg',
+			'file',
 		);
 
 		$field_types = apply_filters( 'pods_seo_analysis_field_types', $field_types );
@@ -180,6 +181,8 @@ class Pods_SEO_WPSEO {
 
 		if ( $pod ) {
 			$inputs = array();
+			$inputs['images'] = array();
+			$inputs['text'] = array();
 
 			$fields = $pod->fields();
 
@@ -198,7 +201,17 @@ class Pods_SEO_WPSEO {
 					continue;
 				}
 
-				$inputs[] = '#pods-form-ui-pods-meta-' . PodsForm::clean( $field['name'] );
+				switch ( $field['type'] ) {
+					case 'file':
+						// Only support images
+						if ( ! empty( $field['file_type'] ) && $field['file_type'] == 'images' ) {
+							$inputs['images'][] = '#pods-form-ui-pods-meta-' . PodsForm::clean( $field['name'] );
+						}
+						break;
+					default:
+						$inputs['text'][] = '#pods-form-ui-pods-meta-' . PodsForm::clean( $field['name'] );
+						break;
+				}
 			}
 
 			if ( ! empty( $inputs ) ) {

--- a/classes/pods-seo-wpseo.php
+++ b/classes/pods-seo-wpseo.php
@@ -107,7 +107,7 @@ class Pods_SEO_WPSEO {
 
 		wp_register_script( 'pods-seo', PODS_SEO_URL . 'assets/pods-seo.js', array( 'jquery' ), PODS_SEO_VERSION, true );
 
-		if ( in_array( $pagenow, array( 'post-new.php', 'post.php' ) ) ) {
+		if ( in_array( $pagenow, array( 'post-new.php', 'post.php', 'term.php' ) ) ) {
 			$settings = $this->get_seo_settings();
 
 			if ( ! empty( $settings ) ) {
@@ -127,7 +127,7 @@ class Pods_SEO_WPSEO {
 	 */
 	public function pods_edit_field_options( $options, $pod ) {
 
-		if ( 'post_type' == $pod['type'] ) {
+		if ( in_array( $pod['type'], array( 'post_type', 'taxonomy', 'media' ) ) ) {
 			$analysis_field_types = $this->get_analysis_field_types();
 
 			$options['advanced'][ __( 'Yoast SEO', 'pods-seo' ) ] = array(


### PR DESCRIPTION
- [x] Add image fields to SEO analysis
- [x] Add image fields images to XML sitemaps attached to the post (also for CPT's)
- [x] Test & validate code ( Jory )
- [ ] Test & validate code ( @sc0ttkclark )

**FIXED in Pods core** (see https://github.com/pods-framework/pods/issues/3707)

Make field option dependency work properly (bug in Pods, not Pods SEO)

`depends-on` >> https://github.com/pods-framework/pods-seo/pull/6/files#diff-31ff2852808c69aa969f76f6c7945455R158
`excludes-on` >> https://github.com/pods-framework/pods-seo/pull/6/files#diff-31ff2852808c69aa969f76f6c7945455R167